### PR TITLE
Add WOOF/USDC market and WOOF DEX Openbook frontend link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Twitter: https://twitter.com/openbookdex
 - [Prism](https://prism.ag/)
 - [Forked Serum UI](https://openbook.lionfi.sh/#/market/8BnEgHoWFysVcuFFX7QztDmzuH8r5ZFvyP3sYwn1XTh6)
 - [Lanatools](https://lanatools.com/lanadex)
+- [WOOF DEX](https://dex.woofsolana.world)
 
 ## Cranks
 

--- a/markets.json
+++ b/markets.json
@@ -94,5 +94,11 @@
     "deprecated": false,
     "name": "MOLA/USDC",
     "programId": "srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX"
+  },
+  {
+    "address": "iufycE4CrRMVHkgym27q28SEyCZ3ZHsN3rLxbPXA7m2",
+    "deprecated": false,
+    "name": "WOOF/USDC",
+    "programId": "srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX"
   }
 ]


### PR DESCRIPTION
The WOOF project has its own Openbook frontend at https://dex.woofsolana.world. Added a link to it as well as our WOOF/USDC Openbook market.